### PR TITLE
Updating user accounts

### DIFF
--- a/src/main/java/com/metalr2/model/exceptions/ErrorMessages.java
+++ b/src/main/java/com/metalr2/model/exceptions/ErrorMessages.java
@@ -4,6 +4,8 @@ public enum ErrorMessages {
 
   USER_WITH_EMAIL_ALREADY_EXISTS("This email address has already been used, please choose another one."),
   USER_WITH_USERNAME_ALREADY_EXISTS("This username has already been used, please choose another one."),
+  ADMINISTRATOR_CANNOT_DISABLE_HIMSELF("An administrator cannot deactivate himself."),
+  ADMINISTRATOR_DISCARD_ROLE("An administrator cannot discard his role."),
   RESOURCE_DOES_NOT_EXIST("Resource does not exist."),
   USER_WITH_ID_NOT_FOUND("User with provided id not found."),
   USER_NOT_FOUND("User with provided email or username not found."),

--- a/src/main/java/com/metalr2/model/user/UserRole.java
+++ b/src/main/java/com/metalr2/model/user/UserRole.java
@@ -48,10 +48,10 @@ public enum UserRole {
   }
 
   public static Set<UserRole> getRoleFromString(String role) {
-    if (role.toLowerCase().equals("administrator")) {
+    if (role.equalsIgnoreCase(ROLE_ADMINISTRATOR.getDisplayName())) {
       return createAdministratorRole();
     }
-    else if (role.toLowerCase().equals("user")) {
+    else if (role.equalsIgnoreCase(ROLE_USER.getDisplayName())) {
       return createUserRole();
     }
     throw new IllegalArgumentException("Role '" + role + "' not found!");

--- a/src/main/java/com/metalr2/model/user/UserRole.java
+++ b/src/main/java/com/metalr2/model/user/UserRole.java
@@ -46,4 +46,14 @@ public enum UserRole {
 
     return userRoleSet;
   }
+
+  public static Set<UserRole> getRoleFromString(String role) {
+    if (role.toLowerCase().equals("administrator")) {
+      return createAdministratorRole();
+    }
+    else if (role.toLowerCase().equals("user")) {
+      return createUserRole();
+    }
+    throw new IllegalArgumentException("Role '" + role + "' not found!");
+  }
 }

--- a/src/main/java/com/metalr2/service/user/UserServiceImpl.java
+++ b/src/main/java/com/metalr2/service/user/UserServiceImpl.java
@@ -10,6 +10,7 @@ import com.metalr2.model.token.TokenRepository;
 import com.metalr2.model.user.UserEntity;
 import com.metalr2.model.user.UserRepository;
 import com.metalr2.model.user.UserRole;
+import com.metalr2.security.CurrentUserSupplier;
 import com.metalr2.service.mapper.UserMapper;
 import com.metalr2.service.token.TokenService;
 import com.metalr2.web.dto.UserDto;
@@ -30,6 +31,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.metalr2.model.user.UserRole.ROLE_ADMINISTRATOR;
+
 @Service
 @Slf4j
 public class UserServiceImpl implements UserService {
@@ -40,17 +43,19 @@ public class UserServiceImpl implements UserService {
   private final JwtsSupport jwtsSupport;
   private final UserMapper userMapper;
   private final TokenService tokenService;
+  private final CurrentUserSupplier currentUserSupplier;
 
   @Autowired
   public UserServiceImpl(UserRepository userRepository, PasswordEncoder passwordEncoder,
                          TokenRepository tokenRepository, JwtsSupport jwtsSupport, UserMapper userMapper,
-                         TokenService tokenService) {
+                         TokenService tokenService, CurrentUserSupplier currentUserSupplier) {
     this.userRepository = userRepository;
     this.passwordEncoder = passwordEncoder;
     this.tokenRepository = tokenRepository;
     this.jwtsSupport = jwtsSupport;
     this.userMapper = userMapper;
     this.tokenService = tokenService;
+    this.currentUserSupplier = currentUserSupplier;
   }
 
   @Override
@@ -104,7 +109,16 @@ public class UserServiceImpl implements UserService {
     UserEntity userEntity = userRepository.findByPublicId(publicId)
                                           .orElseThrow(() -> new ResourceNotFoundException(ErrorMessages.USER_WITH_ID_NOT_FOUND.toDisplayString()));
 
-    userEntity.setEmail(userDto.getEmail());
+    if (publicId.equals(currentUserSupplier.get().getPublicId())) {
+      if (!userDto.isEnabled())
+        throw new IllegalArgumentException(ErrorMessages.ADMINISTRATOR_CANNOT_DISABLE_HIMSELF.toDisplayString());
+      if (userEntity.isAdministrator() && !UserRole.getRoleFromString(userDto.getRole()).contains(ROLE_ADMINISTRATOR))
+        throw new IllegalArgumentException(ErrorMessages.ADMINISTRATOR_DISCARD_ROLE.toDisplayString());
+    }
+
+    userEntity.setUserRoles(UserRole.getRoleFromString(userDto.getRole()));
+    userEntity.setEnabled(userDto.isEnabled());
+
     UserEntity updatedUserEntity = userRepository.save(userEntity);
 
     return userMapper.mapToDto(updatedUserEntity);

--- a/src/main/java/com/metalr2/web/controller/rest/UserRestController.java
+++ b/src/main/java/com/metalr2/web/controller/rest/UserRestController.java
@@ -49,8 +49,8 @@ public class UserRestController {
     return ResponseEntity.ok(response);
   }
 
-  @PutMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE},
-              produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
+  @PostMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE},
+               produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<UserResponse> createUser(@Valid @RequestBody RegisterUserRequest request) {
     UserDto userDto = mapper.map(request, UserDto.class);
     UserDto createdUserDto = userService.createAdministrator(userDto);
@@ -59,8 +59,8 @@ public class UserRestController {
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
-  @PostMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE},
-               produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
+  @PutMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE},
+              produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<UserResponse> updateUser(@Valid @RequestBody UpdateUserRequest request) {
     UserDto userDto = mapper.map(request, UserDto.class);
     UserDto updatedUserDto = userService.updateUser(request.getPublicUserId(), userDto);

--- a/src/main/java/com/metalr2/web/controller/rest/UserRestController.java
+++ b/src/main/java/com/metalr2/web/controller/rest/UserRestController.java
@@ -3,6 +3,7 @@ package com.metalr2.web.controller.rest;
 import com.metalr2.service.user.UserService;
 import com.metalr2.web.dto.UserDto;
 import com.metalr2.web.dto.request.RegisterUserRequest;
+import com.metalr2.web.dto.request.UpdateUserRequest;
 import com.metalr2.web.dto.response.UserResponse;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,9 +12,10 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
@@ -52,8 +54,8 @@ public class UserRestController {
     return ResponseEntity.ok(response);
   }
 
-  @PostMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE},
-               produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
+  @PutMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE},
+              produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
   public ResponseEntity<UserResponse> createUser(@Valid @RequestBody RegisterUserRequest request) {
     UserDto userDto = mapper.map(request, UserDto.class);
     UserDto createdUserDto = userService.createAdministrator(userDto);
@@ -62,4 +64,13 @@ public class UserRestController {
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
+  @PostMapping(consumes = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE},
+               produces = {MediaType.APPLICATION_XML_VALUE, MediaType.APPLICATION_JSON_VALUE})
+  public ResponseEntity<UserResponse> updateUser(@Valid @RequestBody UpdateUserRequest request) {
+    UserDto userDto = mapper.map(request, UserDto.class);
+    UserDto updatedUserDto = userService.updateUser(request.getPublicUserId(), userDto);
+    UserResponse response = mapper.map(updatedUserDto, UserResponse.class);
+
+    return ResponseEntity.status(HttpStatus.OK).body(response);
+  }
 }

--- a/src/main/java/com/metalr2/web/dto/request/UpdateUserRequest.java
+++ b/src/main/java/com/metalr2/web/dto/request/UpdateUserRequest.java
@@ -1,0 +1,22 @@
+package com.metalr2.web.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class UpdateUserRequest {
+
+  @NotBlank
+  private String publicUserId;
+
+  @NotBlank
+  private String role;
+
+  private boolean enabled;
+
+}

--- a/src/main/resources/static/js/admin/users.js
+++ b/src/main/resources/static/js/admin/users.js
@@ -82,13 +82,15 @@ function createAdministrator () {
     $.post({
         url: '/rest/v1/users',
         data: createAdministratorCreateRequest(),
-        type: 'POST',
+        type: 'PUT',
         headers: {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
         },
         success: onCreateAdministratorSuccess,
-        error: onCreateAdministratorError
+        error: function (errorResponse) {
+            onCreateUpdateError(errorResponse, '#create-admin-user-validation-area')
+        }
     });
 }
 
@@ -117,11 +119,12 @@ function onCreateAdministratorSuccess(createResponse) {
 
 /**
  * Error callback for creating a new administrator.
- * @param errorResponse The json response
+ * @param errorResponse     The json response
+ * @param validationAreaId  ID of the area to display errors (create/update)
  */
-function onCreateAdministratorError(errorResponse) {
-    resetCreateAdminUserValidationArea();
-    const validationMessageArea = $('#create-admin-user-validation-area');
+function onCreateUpdateError(errorResponse, validationAreaId) {
+    resetValidationArea(validationAreaId);
+    const validationMessageArea = $(validationAreaId);
     validationMessageArea.addClass("alert alert-danger");
 
     if (errorResponse.status === 400) { // BAD REQUEST
@@ -139,6 +142,18 @@ function onCreateAdministratorError(errorResponse) {
     else {
         validationMessageArea.append("An unexpected error has occurred. Please try again at a later time.");
     }
+}
+
+/**
+ * Creates the json payload from html form to update a user.
+ * @returns {string} Stringified json payload to update a user.
+ */
+function createUpdateUserRequest() {
+    return JSON.stringify({
+        publicUserId: $("#updatePublicId").val(),
+        role: $("#updateRole").val(),
+        enabled: $("#updateStatus").val() === "Enabled",
+    });
 }
 
 /**
@@ -176,15 +191,43 @@ function updateUser () {
  * Sends the update request to the server.
  */
 function sendUpdateUserRequest() {
-    // ToDo: https://trello.com/c/iEGmTlRI
+    $.post({
+        url: '/rest/v1/users',
+        data: createUpdateUserRequest(),
+        type: 'POST',
+        headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        },
+        success: onUpdateUserSuccess,
+        error: function (errorResponse) {
+            onCreateUpdateError(errorResponse, '#update-user-validation-area')
+        }
+    });
 }
 
 /**
- * Resets the user create form.
+ * Success callback for updating a user.
+ * @param updateResponse The json response
+ */
+function onUpdateUserSuccess(updateResponse) {
+    userTable.rows().every(function (rowIndex, tableLoop, rowLoop) {
+        if (userTable.cell(rowIndex, 1).data() === updateResponse.username) {
+            userTable.cell(rowIndex, 3).data(updateResponse.role);
+            userTable.cell(rowIndex, 4).data(updateResponse.enabled);
+        }
+    }).draw();
+
+    resetUpdateUserForm();
+    $('#update-user-dialog').modal('hide');
+}
+
+/**
+ * Resets the user creation form.
  */
 function resetCreateUserForm() {
     $("#create-admin-user-form")[0].reset();
-    resetCreateAdminUserValidationArea();
+    resetValidationArea('#create-admin-user-validation-area');
 }
 
 /**
@@ -192,21 +235,15 @@ function resetCreateUserForm() {
  */
 function resetUpdateUserForm() {
     $("#update-user-form")[0].reset();
-    resetUpdateUserValidationArea();
+    resetValidationArea('#update-user-validation-area');
 }
 
 /**
- * Resets the validation area in create admin user form.
+ * Resets the validation area in create admin or update user form.
+ * @param validationAreaId  ID of the area to reset (create/update)
  */
-function resetCreateAdminUserValidationArea() {
-    const validationMessageArea = $('#create-admin-user-validation-area');
+function resetValidationArea(validationAreaId) {
+    const validationMessageArea = $(validationAreaId);
     validationMessageArea.removeClass('alert alert-danger');
     validationMessageArea.empty();
-}
-
-/**
- * Resets the validation area in update user form.
- */
-function resetUpdateUserValidationArea() {
-    // ToDo: https://trello.com/c/iEGmTlRI
 }

--- a/src/main/resources/static/js/admin/users.js
+++ b/src/main/resources/static/js/admin/users.js
@@ -82,14 +82,14 @@ function createAdministrator () {
     $.post({
         url: '/rest/v1/users',
         data: createAdministratorCreateRequest(),
-        type: 'PUT',
+        type: 'POST',
         headers: {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
         },
         success: onCreateAdministratorSuccess,
         error: function (errorResponse) {
-            onCreateUpdateError(errorResponse, '#create-admin-user-validation-area')
+            onCreateError(errorResponse, '#create-admin-user-validation-area')
         }
     });
 }
@@ -120,9 +120,27 @@ function onCreateAdministratorSuccess(createResponse) {
 /**
  * Error callback for creating a new administrator.
  * @param errorResponse     The json response
+ * @param validationAreaId  ID of the area to display errors (create)
+ */
+function onCreateError(errorResponse, validationAreaId) {
+    onError(errorResponse, validationAreaId);
+}
+
+/**
+ * Error callback for updating a user.
+ * @param errorResponse     The json response
+ * @param validationAreaId  ID of the area to display errors (update)
+ */
+function onUpdateError(errorResponse, validationAreaId) {
+    onError(errorResponse, validationAreaId);
+}
+
+/**
+ * Error callback.
+ * @param errorResponse     The json response
  * @param validationAreaId  ID of the area to display errors (create/update)
  */
-function onCreateUpdateError(errorResponse, validationAreaId) {
+function onError(errorResponse, validationAreaId) {
     resetValidationArea(validationAreaId);
     const validationMessageArea = $(validationAreaId);
     validationMessageArea.addClass("alert alert-danger");
@@ -130,9 +148,9 @@ function onCreateUpdateError(errorResponse, validationAreaId) {
     if (errorResponse.status === 400) { // BAD REQUEST
         validationMessageArea.append("The following errors occurred during server-side validation:");
         const errorsList = $('<ul>', {class: "errors mb-0"}).append(
-            errorResponse.responseJSON.messages.map(message =>
-                $("<li>").text(message)
-            )
+          errorResponse.responseJSON.messages.map(message =>
+            $("<li>").text(message)
+          )
         );
         validationMessageArea.append(errorsList);
     }
@@ -194,14 +212,14 @@ function sendUpdateUserRequest() {
     $.post({
         url: '/rest/v1/users',
         data: createUpdateUserRequest(),
-        type: 'POST',
+        type: 'PUT',
         headers: {
             'Accept': 'application/json',
             'Content-Type': 'application/json',
         },
         success: onUpdateUserSuccess,
         error: function (errorResponse) {
-            onCreateUpdateError(errorResponse, '#update-user-validation-area')
+            onUpdateError(errorResponse, '#update-user-validation-area')
         }
     });
 }
@@ -211,7 +229,7 @@ function sendUpdateUserRequest() {
  * @param updateResponse The json response
  */
 function onUpdateUserSuccess(updateResponse) {
-    userTable.rows().every(function (rowIndex, tableLoop, rowLoop) {
+    userTable.rows().every(function (rowIndex) {
         if (userTable.cell(rowIndex, 1).data() === updateResponse.username) {
             userTable.cell(rowIndex, 3).data(updateResponse.role);
             userTable.cell(rowIndex, 4).data(updateResponse.enabled);

--- a/src/main/resources/templates/admin/users/update.html
+++ b/src/main/resources/templates/admin/users/update.html
@@ -13,6 +13,8 @@
                 </button>
             </div>
             <div class="modal-body">
+                <div id="update-user-validation-area" class="small" role="alert">
+                </div>
                 <nav>
                     <div class="nav nav-tabs" id="nav-tab" role="tablist">
                         <a class="nav-item nav-link active" id="nav-master-data-tab" data-toggle="tab" href="#nav-master-data" role="tab" aria-controls="nav-home" aria-selected="true">Master data</a>

--- a/src/test/java/com/metalr2/service/user/UserServiceTest.java
+++ b/src/test/java/com/metalr2/service/user/UserServiceTest.java
@@ -424,8 +424,6 @@ class UserServiceTest implements WithAssertions {
     Throwable throwable = catchThrowable(() -> userService.updateUser(PUBLIC_ID, userDtoForUpdate));
 
     // then
-    verify(userRepository, times(1)).findByPublicId(PUBLIC_ID);
-    verify(currentUserSupplier, times(1)).get();
     assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
     assertThat(throwable).hasMessage(ErrorMessages.ADMINISTRATOR_DISCARD_ROLE.toDisplayString());
   }
@@ -447,8 +445,6 @@ class UserServiceTest implements WithAssertions {
     Throwable throwable = catchThrowable(() -> userService.updateUser(PUBLIC_ID, userDtoForUpdate));
 
     // then
-    verify(userRepository, times(1)).findByPublicId(PUBLIC_ID);
-    verify(currentUserSupplier, times(1)).get();
     assertThat(throwable).isInstanceOf(IllegalArgumentException.class);
     assertThat(throwable).hasMessage(ErrorMessages.ADMINISTRATOR_CANNOT_DISABLE_HIMSELF.toDisplayString());
   }

--- a/src/test/java/com/metalr2/web/DtoFactory.java
+++ b/src/test/java/com/metalr2/web/DtoFactory.java
@@ -37,6 +37,7 @@ public class DtoFactory {
           .username(username)
           .email(email)
           .plainPassword("xxx")
+          .role("User")
           .enabled(true)
           .build();
     }

--- a/src/test/java/com/metalr2/web/RestAssuredRequestHandler.java
+++ b/src/test/java/com/metalr2/web/RestAssuredRequestHandler.java
@@ -59,13 +59,13 @@ public class RestAssuredRequestHandler {
           .then();
   }
 
-  public ValidatableResponse doDelete(String pathSegment, ContentType accept) {
+  public ValidatableResponse doPut(Object request, ContentType accept) {
     return given()
-            .contentType(accept)
             .accept(accept)
-           .when()
-            .delete(requestUri + pathSegment)
-           .then();
+            .contentType(accept)
+            .body(request)
+          .when()
+            .put(requestUri)
+          .then();
   }
-
 }

--- a/src/test/java/com/metalr2/web/controller/rest/UserRestControllerIT.java
+++ b/src/test/java/com/metalr2/web/controller/rest/UserRestControllerIT.java
@@ -198,7 +198,7 @@ class UserRestControllerIT implements WithAssertions, WithIntegrationTestProfile
       ArgumentCaptor<UserDto> userDtoCaptor = ArgumentCaptor.forClass(UserDto.class);
 
       // when
-      requestHandler.doPut(request, ContentType.JSON);
+      requestHandler.doPost(request, ContentType.JSON);
 
       // then
       verify(userService, times(1)).createAdministrator(userDtoCaptor.capture());
@@ -214,7 +214,7 @@ class UserRestControllerIT implements WithAssertions, WithIntegrationTestProfile
       when(userService.createAdministrator(any())).thenReturn(createdUserDto);
 
       // when
-      ValidatableResponse response = requestHandler.doPut(request, ContentType.JSON);
+      ValidatableResponse response = requestHandler.doPost(request, ContentType.JSON);
 
       // then
       response.contentType(ContentType.JSON)
@@ -232,7 +232,7 @@ class UserRestControllerIT implements WithAssertions, WithIntegrationTestProfile
       when(userService.createAdministrator(any())).thenThrow(UserAlreadyExistsException.class);
 
       // when
-      ValidatableResponse response = requestHandler.doPut(request, ContentType.JSON);
+      ValidatableResponse response = requestHandler.doPost(request, ContentType.JSON);
 
       // then
       response.contentType(ContentType.JSON)
@@ -245,7 +245,7 @@ class UserRestControllerIT implements WithAssertions, WithIntegrationTestProfile
     @DisplayName("Should return status 400 if creating of administrator does not pass validation")
     void should_return_400(RegisterUserRequest request, int expectedErrorCount) {
       // when
-      ValidatableResponse response = requestHandler.doPut(request, ContentType.JSON);
+      ValidatableResponse response = requestHandler.doPost(request, ContentType.JSON);
 
       // then
       response.contentType(ContentType.JSON)
@@ -299,7 +299,7 @@ class UserRestControllerIT implements WithAssertions, WithIntegrationTestProfile
       when(userService.updateUser(USER_ID, modelMapper.map(updateUserRequest, UserDto.class))).thenReturn(userDto);
 
       // when
-      ValidatableResponse response = requestHandler.doPost(updateUserRequest, ContentType.JSON);
+      ValidatableResponse response = requestHandler.doPut(updateUserRequest, ContentType.JSON);
 
       // then
       response.contentType(ContentType.JSON)


### PR DESCRIPTION
Updating a user's role and status is now possible via the user administration. I pulled the last checkbox from the card into a new one because it does not really have anything to do with this topic and I wanted to finally get this done here.